### PR TITLE
3주차 mission, practice 문제 해결

### DIFF
--- a/3rd_hashTable/mission/베스트앨범.java
+++ b/3rd_hashTable/mission/베스트앨범.java
@@ -1,0 +1,38 @@
+package mission;
+
+import java.util.*;
+class 베스트앨범 {
+    public int[] solution(String[] genres, int[] plays) {
+
+        Map<String, Integer> genreMap = new HashMap<>();
+
+        for(int i = 0; i < genres.length; i++) {
+            genreMap.put(genres[i], genreMap.getOrDefault(genres[i], 0) + plays[i]);
+        }
+
+        List<String> mostPlays = new ArrayList<>(genreMap.keySet());
+
+        Collections.sort(mostPlays, (a,b) -> genreMap.get(b) - genreMap.get(a));
+//        Collections.sort(mostPlays, Collections.reverseOrder());
+        List<Integer> res = new ArrayList<>();
+
+        for(String play : mostPlays) {
+            Map<Integer, Integer> playMap = new HashMap<>();
+            for (int i = 0; i < genres.length; i++) {
+                if (play.equals(genres[i])) {
+                    playMap.put(i, plays[i]);
+                }
+            }
+
+            List<Integer> index = new ArrayList<>(playMap.keySet()); // 4,1,3,0...
+
+            Collections.sort(index, (a,b) -> playMap.get(b) - playMap.get(a));
+            res.add(index.get(0));
+            if (index.size() > 1) res.add(index.get(1));
+        }
+
+        int [] arr_res = new int[res.size()];
+        for(int i = 0; i < res.size(); i++) arr_res[i] = res.get(i);
+        return arr_res;
+    }
+}

--- a/3rd_hashTable/mission/의상.java
+++ b/3rd_hashTable/mission/의상.java
@@ -1,0 +1,27 @@
+package mission;
+
+import java.util.*;
+class 의상 {
+    public int solution(String[][] clothes) {
+        int answer = 0;
+        Map<String, List<String>> map = new HashMap<>();
+
+        for (String[] cloth : clothes) {
+            map.put(cloth[1], new ArrayList<>());
+        }
+
+        for (String[] cloth : clothes) {
+            map.get(cloth[1]).add(cloth[0]);
+        }
+
+        List<String> list = new ArrayList<>(map.keySet());
+
+        int res = 1;
+        for (String key : list) {
+            List<String> cloth = map.get(key);
+            res *= (cloth.size() + 1); // 옷을 안입는 경우를 포함하여 + 1을 해줌
+        }
+
+        return res - 1;
+    }
+}

--- a/3rd_hashTable/mission/폰켓몬.java
+++ b/3rd_hashTable/mission/폰켓몬.java
@@ -1,0 +1,17 @@
+package mission;
+
+import java.util.*;
+class 폰켓몬 {
+    public int solution(int[] nums) {
+        int answer = 0;
+
+        Set<Integer> set = new HashSet<>();
+
+        for(int num : nums) set.add(num);
+        int len = nums.length / 2;
+
+        if (set.size() > len) return len;
+        else return set.size();
+
+    }
+}

--- a/3rd_hashTable/practice/Main.java
+++ b/3rd_hashTable/practice/Main.java
@@ -1,0 +1,27 @@
+package practice;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/*
+    테이블: d[i]: i까지 도달하는데 필요한 연산의 최솟값
+    점화식: d[i]: Math.min(d[i/3] , d[i/2], d[i] + 1)
+ */
+public class Main {
+    static int x;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        x = Integer.parseInt(br.readLine());
+
+        long [] dp = new long [x + 1];
+        dp[0] = 0; dp[1] = 0;
+        for(int i = 2; i <= x; i++) {
+            dp[i] = dp[i-1] + 1;
+            if (i % 3 == 0) dp[i] = Math.min(dp[i] , dp[i/3] + 1);
+            if (i % 2 == 0) dp[i] = Math.min(dp[i], dp[i/2] + 1);
+
+        }
+        System.out.println(dp[x]);
+    }
+}

--- a/3rd_hashTable/practice/boj1269.java
+++ b/3rd_hashTable/practice/boj1269.java
@@ -1,0 +1,41 @@
+package practice;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class boj1269 {
+    static int n, m;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        Map<Integer, Integer> map = new HashMap<>();
+        st = new StringTokenizer(br.readLine());
+
+        int a_size = 0;
+        for(int i = 0; i < n; i++) {
+            int num = Integer.parseInt(st.nextToken());
+            map.put(num, map.getOrDefault(num, 0) + 1);
+            a_size++;
+        }
+
+        int dup = 0;
+        int b_size = 0;
+        st = new StringTokenizer(br.readLine());
+        for(int i = 0; i < m; i++) {
+            int num = Integer.parseInt(st.nextToken());
+            if (map.containsKey(num)) {
+                dup++;
+            }
+            b_size++;
+        }
+        // System.out.println(a_size + " " + dup + " " + b_size);
+        System.out.println(a_size - dup + b_size - dup);
+    }
+}

--- a/3rd_hashTable/practice/boj1764.java
+++ b/3rd_hashTable/practice/boj1764.java
@@ -1,0 +1,51 @@
+package practice;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class boj1764 {
+    static int n, m;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        Set<String> set = new HashSet<>();
+        for(int i = 0; i < n; i++) {
+            set.add(br.readLine());
+        }
+
+        List<String> res = new ArrayList<>();
+        int len = 0;
+        for(int i = 0; i < m; i++) {
+            String input = br.readLine();
+            if (set.contains(input)) {
+                len++;
+                res.add(input);
+            }
+        }
+
+        Collections.sort(res);
+
+        System.out.println(len);
+        for (String re : res) {
+            System.out.println(re);
+        }
+    }
+}
+
+/*
+    List contains 메서드 시간복잡도: O(n)
+    Set contains 메서드 시간복잡도: O(1)
+
+
+ */

--- a/3rd_hashTable/practice/boj9933.java
+++ b/3rd_hashTable/practice/boj9933.java
@@ -1,0 +1,32 @@
+package practice;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class boj9933 {
+    static int n;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+
+        List<String> list = new ArrayList<>();
+        for(int i = 0; i < n; i++) {
+            String input = br.readLine();
+            list.add(input);
+        }
+
+        for(int i = 0; i < list.size(); i++) {
+            String word = list.get(i);
+            String reverse = new StringBuilder(word).reverse().toString();
+            if (list.contains(reverse)) {
+                int len = reverse.length();
+                System.out.println(len + " " + reverse.charAt(len / 2));
+                return;
+            }
+        }
+    }
+}

--- a/3rd_hashTable/practice/완주하지못한선수.java
+++ b/3rd_hashTable/practice/완주하지못한선수.java
@@ -1,0 +1,37 @@
+package practice;
+
+import java.util.*;
+class 완주하지못한선수 {
+    public String solution(String[] participant, String[] completion) {
+        String answer = "";
+
+        Arrays.sort(participant);
+        Arrays.sort(completion);
+
+        int n = completion.length;
+
+        for(int i = 0; i < n; i++) {
+            if (!completion[i].equals(participant[i])) {
+                return participant[i];
+            }
+        }
+
+        return participant[n];
+    }
+}
+
+/*
+테스트 1 〉	통과 (0.19ms, 74.1MB)
+테스트 2 〉	통과 (0.33ms, 77.7MB)
+테스트 3 〉	통과 (1.75ms, 78.4MB)
+테스트 4 〉	통과 (2.82ms, 74.9MB)
+테스트 5 〉	통과 (4.12ms, 77.1MB)
+테스트 6 〉	통과 (0.33ms, 79MB)
+테스트 7 〉	통과 (0.26ms, 73.5MB)
+효율성  테스트
+테스트 1 〉	통과 (121.16ms, 81.9MB)
+테스트 2 〉	통과 (205.37ms, 87.8MB)
+테스트 3 〉	통과 (271.98ms, 94.7MB)
+테스트 4 〉	통과 (343.76ms, 95.3MB)
+테스트 5 〉	통과 (349.38ms, 97.1MB)
+ */

--- a/3rd_hashTable/practice/전화번호_목록.java
+++ b/3rd_hashTable/practice/전화번호_목록.java
@@ -1,0 +1,15 @@
+package practice;
+
+import java.util.*;
+class 전화번호_목록 {
+    public boolean solution(String[] phone_book) {
+        Arrays.sort(phone_book);
+        for(int i = 0; i < phone_book.length - 1; i++) {
+            if (phone_book[i+1].startsWith(phone_book[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
아직 완료하지 못한 문제

문제 번호 | 문제 이름 | 문제 링크
-- | -- | --
19583 | 싸이버 개강총회 | https://www.acmicpc.net/problem/19583
27440 | 1로 만들기 3 | https://www.acmicpc.net/problem/27440
2295 | 세 수의합 | https://www.acmicpc.net/problem/2295

## 문제 풀이 회고


42579 | 베스트엘범 | https://school.programmers.co.kr/learn/courses/30/lessons/42579
-- | -- | --

전체 경우의 수를 구하는 과정이 좀 헷갈렸는데, 옷의 갯수 + 1 (여기서 1은 옷을 입지 않는 경우의 수)를 곱해주며, 마지막엔 1을 빼줍니다. 여기서 1을 빼주는 이유는 아무것도 입지 않는 경우이기 때문에 빼줘야 합니다.



42579 | 베스트엘범 | https://school.programmers.co.kr/learn/courses/30/lessons/42579
-- | -- | --

장르 내에서 재생 횟수가 같은 노래 중에서는 고유 번호가 낮은 노래를 먼저 수록합니다. 이 조건을 보고 해쉬맵을 `key=고유번호, value=재생 횟수` 형태로 저장을 했습니다.

        Collections.sort(mostPlays, (a,b) -> genreMap.get(b) - genreMap.get(a));
        Collections.sort(mostPlays, Collections.reverseOrder());

헷갈렸던 부분은 기존엔 `Collections.reverseOrder()` 를 통해서 key를 기준으로 내림차순을 해주었는데, 이렇게 되면 안되고 재생횟수를 기준으로 내림차순을 해줘야 합니다. 그래서 람다식을 활용해서 구현해 주었습니다.


1764 | 듣보잡 | https://www.acmicpc.net/problem/1764
-- | -- | --

이 문제에서 N, M이 500,000 사이즈고 시간 제한은 2초이기 때문에 시간 초과에 대해서 유의하고 풀이해야 합니다.

기존엔 List 자료구조를 사용하여 contains 메서드를 통해서 답을 찾으려고 헀는데, 이렇게 되니 O(n * m) => 2500억이 되어 2초 안에 해결할 수 없습니다.

Set 자료구조에선 contains 메서드의 실행 시간이 O(1)이기 때문에, O(n) => 50만으로 충분히 2초안에 통과할 수 있습니다.

List contains 시간복잡도: O(n)
Set contains 시간복잡도: O(1)


42577 | 전화번호 목록 | https://school.programmers.co.kr/learn/courses/30/lessons/42577
-- | -- | --

이 문제의 경우도 phone_book의 길이가 100만이기 때문에 시간 초과에 주의해야 합니다.

처음에 brute force로 풀었을 때 당연히 시간 초과가 났고, 투포인터 알고리즘으로 문제를 해결하려고 했지만 마지막 효율성 테스트 2개에서 시초가 발생했습니다.

<img width="408" alt="스크린샷 2024-07-25 오후 7 43 59" src="https://github.com/user-attachments/assets/40013cee-9ccd-4948-9f28-dd6e2f3fb099">

다른 답지를 찾아보니 의외로 간단하게 풀렸는데, Arrays.sort를 해줘서 앞번호가 뒷번호의 접두어인지 확인합니다. 접두어 하나를 정해놓고 배열들을 순회하는 방식을 생각했는데, sort를 해주면 접두어가 비슷한 원소들끼리 나열이 되고, O(n)으로 탐색을 진행하면 됐던 문제였습니다.


42576 | 완주하지 못한 선수 | https://school.programmers.co.kr/learn/courses/30/lessons/42576
-- | -- | --

동명이인이 존재하기 때문에, 참가자와 완주자를 sorting 해주고 앞에서 부터 비교해줍니다. 만약 이 때 두 값이 다르다는 뜻은 동명이인이 존재한다는 뜻 이므로 바로 해당 선수를 return 해줍니다.

만약에 탐색이 끝날 때 까지 모든 원소가 동일하다면, 참가자의 마지막 원소를 리턴해주면 됩니다.

<img width="375" alt="스크린샷 2024-07-25 오후 7 54 02" src="https://github.com/user-attachments/assets/cceb586e-0086-470f-a624-063bcf3ba495">

문제에서 주어진 n의 사이즈가 10만이고, sorting의 시간복잡도가 O(nlogn) 이므로 효율성 테스트를 진행할 때 꽤 시간이 걸려서 틀리는줄 알았는데 다행히 통과했습니다.

O(nlogn) -> O(n)으로 시간복잡도를 줄일 수 있는 로직을 찾아봐야 할 것 같습니다.



